### PR TITLE
[libzip] Add windows_crypto feature

### DIFF
--- a/ports/libzip/CONTROL
+++ b/ports/libzip/CONTROL
@@ -2,7 +2,7 @@ Source: libzip
 Version: rel-1-6-1
 Homepage: https://github.com/nih-at/libzip
 Build-Depends: zlib
-Default-Features: openssl, bzip2
+Default-Features: openssl, bzip2, windows_crypto
 Description: A library for reading, creating, and modifying zip archives.
 
 Feature: bzip2
@@ -12,3 +12,6 @@ Description: Support bzip2-compressed zip archives
 Feature: openssl
 Build-Depends: openssl
 Description: AES (encryption) support using OpenSSL
+
+Feature: windows_crypto
+Description: Support BCrypt/CNG-based crypto on Windows

--- a/ports/libzip/portfile.cmake
+++ b/ports/libzip/portfile.cmake
@@ -8,8 +8,9 @@ vcpkg_from_github(
 
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    openssl OPENSSL
-    bzip2 BZIP2
+    openssl ENABLE_OPENSSL
+    bzip2 ENABLE_BZIP2
+    windows_crypto ENABLE_WINDOWS_CRYPTO
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
The new BCrypt/CNG-based crypto uses BCryptDeriveKeyPBKDF2 which is only
available since WinNT 6.1. It is important to me as a consumer of libzip
through vcpkg to be able to turn this off.